### PR TITLE
Use claimRef and volumeName to match recycler PV & PVC

### DIFF
--- a/volrecycler/README.md
+++ b/volrecycler/README.md
@@ -1,6 +1,8 @@
 # Subvol recycler
 
-This directory contains the recycler that cleans out PVs once they are released (the associated PersistentVolumeClaim is deleted), deletes all the files in the underlying directory, and marks the PV as ready to be used again.
+This directory contains the recycler that cleans out PVs once they are released
+(the associated PersistentVolumeClaim is deleted), deletes all the files in the
+underlying directory, and marks the PV as ready to be used again.
 
 ## Overview
 
@@ -39,7 +41,10 @@ The recycler also needs permission to:
 * Run the recycling script as `UID=0` so that it has sufficient permissions to
 delete the files in the PV subdirectories.
 
-This is handled by creating a service account with sufficient permissions. See `volrecycler-sa.yml` for details. Also, for OpenShift, permitting a container to run as UID 0 requires additional permissions. Once the service account has been created, run:
+This is handled by creating a service account with sufficient permissions. See
+`volrecycler-sa.yml` for details. Also, for OpenShift, permitting a container to
+run as UID 0 requires additional permissions. Once the service account has been
+created, run:
 ```sh
 $ oc adm policy add-scc-to-user anyuid system:serviceaccount:glusterfs:volrecycler-sa
 ```
@@ -54,9 +59,12 @@ Before running this pod, some configuration is necessary:
 volume to be monitored. `Endpoint:` must match the endpoint that was created
 earlier, and it must be the same as the list of gluster servers in the PVs we
 will be recycling.
-* The PersistentVolume should be classed such that we are assured of claiming
-it.
-* The PersistentVolumeClaim needs to match the PersistentVolume
+* The PersistentVolume and PersistentVolumeClaim need to be paired such that we
+are assured of getting exactly this PV attached to the recycler pod.
+
+  This is accomplished by putting a `claimRef:` on the PV that refers to the PVC
+  and a `volumeName:` on the PVC that refers to the PV.
+
 * The pod description needs to have `args:` set to refer to the IPs and volume
 name from the Endpoint and PersistentVolume.
 

--- a/volrecycler/volrecycler.yml
+++ b/volrecycler/volrecycler.yml
@@ -12,11 +12,13 @@ spec:
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: glustersupervol-testvol
   glusterfs:
     endpoints: glusterfs-cluster
     path: testvol
     readOnly: false
+  claimRef:
+    name: glustersupervol-testvol
+    namespace: glusterfs
 
 ---
 
@@ -31,7 +33,7 @@ spec:
   resources:
     requests:
       storage: 1Mi
-  storageClassName: glustersupervol-testvol
+  volumeName: glustersupervol-testvol
 
 ---
 


### PR DESCRIPTION
Previously, storageClass was being used to ensure the recycler's pv and
pvc were matched. Using claimRef and volumeName are the correct way to
do this.

Fixes #2